### PR TITLE
web site maintenance

### DIFF
--- a/src/main/java/org/codehaus/mojo/nbm/BuildInstallersMojo.java
+++ b/src/main/java/org/codehaus/mojo/nbm/BuildInstallersMojo.java
@@ -40,7 +40,7 @@ import org.apache.tools.ant.util.StringUtils;
  * Build installers for Mavenized NetBeans application.
  * Creates installers for supported operating systems
  * and packages each installer as a deployable artifact.
- * <p>See a <a href="http://mojo.codehaus.org/nbm-maven/nbm-maven-plugin/buildinstexample.html">how-to</a> on customizing the installer.
+ * <p>See a <a href="http://www.mojohaus.org/nbm-maven-plugin/buildinstexample.html">how-to</a> on customizing the installer.
  * @author <a href="mailto:frantisek@mantlik.cz">Frantisek Mantlik</a>
  */
 @Mojo(name="build-installers", 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -36,7 +36,7 @@ or the repository manager you are using. The repository hosts binaries of NetBea
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>nbm-maven-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${project.version}</version>
                 <extensions>true</extensions>
             </plugin>
             <plugin> <!-- required since nbm-plugin 3.0-->
@@ -255,7 +255,7 @@ and are to be exposed for reuse by other modules.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>nbm-maven-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>${project.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                    <publicPackages>

--- a/src/site/apt/upgrade.apt
+++ b/src/site/apt/upgrade.apt
@@ -20,11 +20,11 @@ HOW TO: Migrate from older version of the plugin
 
 {Upgrading to 3.9}
 
-In 3.9, the <code>populate-repository</code> goal is moved to separate plugin.
+ In 3.9, the <<<populate-repository>>> goal is moved to separate plugin.
 
 {Upgrading to 3.8}
 
- In 3.8 the <code>descriptor</code> parameter is deprecated and is replaced by equivalent plugin parameters. 
+ In 3.8 the <<<descriptor>>> parameter is deprecated and is replaced by equivalent plugin parameters. 
 The values from descriptor are still applied, warnings are printed. In future releases the parameter will be removed.
 
 {Upgrading from 2.6 version to 3.0}
@@ -85,7 +85,7 @@ public vs. private packages constraint etc)
 The result was a deprecated state that made all classes publicly accessible from other modules
 and printed a warning to the application's log file. In <<3.0>>, we introduced a new optional parameter <<<publicPackages>>>
 that lists all public packages in the module. If not defined, no package is exported as public. See
-{{{http://jira.codehaus.org/browse/MNBMODULE-32}issue MNBMODULE-32}} for details. If you have previously
+{{{https://github.com/mojohaus/nbm-maven-plugin/issues/3}issue}} for details. If you have previously
 placed the <<OpenIDE-Module-Public-Packages>> entry in the manifest file manually, it will not be overriden by the new parameter.
 
 =======================================================================


### PR DESCRIPTION
Hi, 
 this pr is for website.
 It fixes link in buildinstallers-mojo to remove hardcoded codehaus,
 The upgrade page contains non valid tag. The issue on jira is quoted but was no more alive. (I recreated #3 to maintain history.
 To show current version of the plugin in website I propose to use vm extension on the index web page.
