### PR TITLE
Include OSGi JARs when generating AutoUpdate update.xml, otherwise HT…

### DIFF
--- a/src/main/java/org/codehaus/mojo/nbm/CreateUpdateSiteMojo.java
+++ b/src/main/java/org/codehaus/mojo/nbm/CreateUpdateSiteMojo.java
@@ -195,7 +195,7 @@ public class CreateUpdateSiteMojo
                     art = res.getConvertedArtifact();
                 }
 
-                if ( art.getType().equals( "nbm-file" ) )
+                if ( art.getType().equals( "nbm-file" ) || res.isOSGiBundle() )
                 {
                     Copy copyTask = (Copy) antProject.createTask( "copy" );
                     copyTask.setOverwrite( true );
@@ -220,10 +220,6 @@ public class CreateUpdateSiteMojo
                         throw new MojoExecutionException( "Cannot merge nbm files into autoupdate site", ex );
                     }
 
-                }
-                if ( res.isOSGiBundle() )
-                {
-                    // TODO check for bundles
                 }
             }
             getLog().info( "Created NetBeans module cluster(s) at " + nbmBuildDirFile.getAbsoluteFile() );
@@ -310,6 +306,7 @@ public class CreateUpdateSiteMojo
         FileSet fs = new FileSet();
         fs.setDir( nbmBuildDirFile );
         fs.createInclude().setName( "**/*.nbm" );
+        fs.createInclude().setName( "**/*.jar" );
         descTask.addFileset( fs );
         try
         {


### PR DESCRIPTION
…ML/Java APIs in 8.1 release may be omitted. I hope this is the right place to contribute patches now. Could this change be included in some new version of the plugin, hopefully available before 8.1 is out?

My application has dependency on 

```
    <dependency>
        <groupId>org.netbeans.html</groupId>
        <artifactId>ko-ws-tyrus</artifactId>
        <version>1.1</version>
    </dependency>
```

and its JARs are not included in the generated update catalog. My fix includes them.
