### PR TITLE
fix-plexus api error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
-            <version>1.2</version>
+            <version>3.0.1</version>
             <exclusions>
                 <exclusion>
                     <artifactId>plexus-component-api</artifactId>


### PR DESCRIPTION
Hi,  
  I was testing the new nbm-plugin with maven 3.0.5 minimum version and I encounter the following error on the default-branding:
...
Caused by: org.apache.maven.plugin.PluginContainerException: An API incompatibility was encountered while executing org.codehaus.mojo:nbm-maven-plugin:4.1-SNAPSHOT:branding: java.lang.NoSuchMethodError: org.codehaus.plexus.components.io.resources.PlexusIoFileResourceCollection.<init>(Lorg/codehaus/plexus/logging/Logger;)V
....

The fix is just done by upgrading the plexus-archiver version.
