### PR TITLE
make site generation compatible with maven 3.3.3 and jdk 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>mojo-parent</artifactId>
-        <version>37</version>
+        <version>38</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -110,7 +110,7 @@
             <plugin>
                 <groupId>org.codehaus.modello</groupId>
                 <artifactId>modello-maven-plugin</artifactId>
-                <version>1.5</version>
+                <version>1.8.3</version>
                 <executions>
                     <execution>
                         <id>build</id>
@@ -169,13 +169,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.4</version>
                 <configuration> 
                     <reportPlugins>
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-project-info-reports-plugin</artifactId>
-                            <version>2.4</version>
+                            <version>2.8.1</version>
                             <reports>
                                 <report>dependencies</report>
                                 <report>dependency-management</report>
@@ -213,7 +213,7 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-checkstyle-plugin</artifactId>
-                            <version>2.9.1</version>
+                            <version>2.16</version>
                             <reports>
                                 <report>checkstyle</report>
                             </reports>
@@ -221,42 +221,43 @@
                                 <configLocation>config/maven_checks.xml</configLocation>
                                 <headerLocation>config/maven-header.txt</headerLocation>
                             </configuration>
+                            
                         </plugin>
                         
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-javadoc-plugin</artifactId>
-                            <version>2.8.1</version>
+                            <version>2.10.3</version>
                             <configuration>
                                 <quiet>true</quiet>
                                 <links>
                                     <!--<link>http://download-llnw.oracle.com/javaee/1.4/api/</link>-->
-                                    <link>http://commons.apache.org/collections/apidocs-COLLECTIONS_3_0/</link>
+                                    <!-- unreachable site <link>http://commons.apache.org/collections/apidocs-COLLECTIONS_3_0/</link>-->
                                     <link>http://commons.apache.org/dbcp/apidocs/</link>
                                     <link>http://commons.apache.org/fileupload/apidocs/</link>
                                     <link>http://commons.apache.org/logging/apidocs/</link>
                                     <link>http://commons.apache.org/pool/apidocs/</link>
                                     <link>http://junit.sourceforge.net/javadoc/</link>
                                     <link>http://logging.apache.org/log4j/1.2/apidocs/</link>
-                                    <link>http://jakarta.apache.org/regexp/apidocs/</link>
+                                    <!-- unreachable site <link>http://jakarta.apache.org/regexp/apidocs/</link> -->
                                     <link>http://velocity.apache.org/engine/releases/velocity-1.5/apidocs/</link>
                                     <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-artifact/apidocs/</link>
                                     <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-model/apidocs/</link>
                                     <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-plugin-api/apidocs/</link>
-                                    <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-project/apidocs/</link>
-                                    <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-reporting/maven-reporting-api/apidocs/</link>
+                                    <!-- unreachable site <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-project/apidocs/</link>-->
+                                    <!-- unreachable site <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-reporting/maven-reporting-api/apidocs/</link>-->
                                     <link>http://maven.apache.org/ref/${mojo.javadoc.mavenVersion}/maven-settings/apidocs/</link>
                                 </links>
                                 <tagletArtifacts>
                                     <tagletArtifact>
                                         <groupId>org.apache.maven.plugin-tools</groupId>
                                         <artifactId>maven-plugin-tools-javadoc</artifactId>
-                                        <version>2.8</version>
+                                        <version>3.4</version>
                                     </tagletArtifact>
                                     <tagletArtifact>
                                         <groupId>org.codehaus.plexus</groupId>
                                         <artifactId>plexus-component-javadoc</artifactId>
-                                        <version>1.5.5</version>
+                                        <version>1.6</version>
                                     </tagletArtifact>
                                 </tagletArtifacts>
                             </configuration>
@@ -273,12 +274,12 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-jxr-plugin</artifactId>
-                            <version>2.3</version>
+                            <version>2.5</version>
                         </plugin>
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-plugin-plugin</artifactId>
-                            <version>3.1</version>
+                            <version>3.4</version>
                             <configuration>
                                 <requirements>
                                     <!--
@@ -292,7 +293,7 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-pmd-plugin</artifactId>
-                            <version>2.7.1</version>
+                            <version>3.5</version>
                             <configuration>
                                 <targetJdk>1.5</targetJdk>
                             </configuration>
@@ -300,7 +301,7 @@
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-linkcheck-plugin</artifactId>
-                            <version>1.1</version>
+                            <version>1.2</version>
                             <configuration>
                                 <excludedLinks>
                                     <excludedLink>../../images/codehaus-small.png</excludedLink>
@@ -315,7 +316,7 @@
                         <plugin>
                             <groupId>org.codehaus.mojo</groupId>
                             <artifactId>cobertura-maven-plugin</artifactId>
-                            <version>2.6</version>
+                            <version>2.7</version>
                             <configuration>
                                 <instrumentation>
                                     <excludes>
@@ -335,6 +336,18 @@
                         
                     </reportPlugins>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.shared</groupId>
+                        <artifactId>maven-shared-resources</artifactId>
+                        <version>2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>1.10</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>
@@ -386,7 +399,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0</version>
+            <version>3.0.22</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -458,7 +471,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>12.0</version>
+            <version>18.0</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/src/main/java/org/codehaus/mojo/nbm/CollectLibrariesNodeVisitor.java
+++ b/src/main/java/org/codehaus/mojo/nbm/CollectLibrariesNodeVisitor.java
@@ -65,6 +65,12 @@ public class CollectLibrariesNodeVisitor
 
     /**
      * Creates a dependency node visitor that collects visited nodes for further processing.
+     * @param explicitLibraries list of explicit libraries
+     * @param runtimeArtifacts list of runtime artifacts
+     * @param examinerCache cache of netbeans manifest for artifacts
+     * @param log mojo logger
+     * @param root dependency to start collect with
+     * @param useOsgiDependencies whether to allow osgi dependencies or not
      */
     public CollectLibrariesNodeVisitor( List<String> explicitLibraries,
         List<Artifact> runtimeArtifacts, Map<Artifact, ExamineManifest> examinerCache,
@@ -167,6 +173,7 @@ public class CollectLibrariesNodeVisitor
      * Gets the list of collected dependency nodes.
      * 
      * @return the list of collected dependency nodes
+     * @throws MojoExecutionException if a throwable is set
      */
     public List<Artifact> getArtifacts()
         throws MojoExecutionException

--- a/src/main/java/org/codehaus/mojo/nbm/CollectModuleLibrariesNodeVisitor.java
+++ b/src/main/java/org/codehaus/mojo/nbm/CollectModuleLibrariesNodeVisitor.java
@@ -62,6 +62,11 @@ public class CollectModuleLibrariesNodeVisitor
 
     /**
      * Creates a dependency node visitor that collects visited nodes for further processing.
+     * @param runtimeArtifacts list of runtime artifacts
+     * @param examinerCache cache of netbeans manifest for artifacts
+     * @param log mojo logger
+     * @param root dependency to start collect with
+     * @param useOSGiDependencies whether to allow osgi dependencies or not
      */
     public CollectModuleLibrariesNodeVisitor(
         List<Artifact> runtimeArtifacts, Map<Artifact, ExamineManifest> examinerCache,
@@ -182,7 +187,7 @@ public class CollectModuleLibrariesNodeVisitor
     /**
      * modules declared in the project's pom
      * @return a map of module artifact lists, key is the dependencyConflictId
-     * @throws org.apache.maven.plugin.MojoExecutionException
+     * @throws MojoExecutionException if an unexpected problem occurs
      */
     public Map<String, List<Artifact>> getDeclaredArtifacts()
         throws MojoExecutionException
@@ -197,7 +202,7 @@ public class CollectModuleLibrariesNodeVisitor
     /**
      * modules that were picked up transitively
      * @return a map of module artifact lists, key is the dependencyConflictId
-     * @throws org.apache.maven.plugin.MojoExecutionException
+     * @throws MojoExecutionException if an unexpected problem occurs
      */
     public Map<String, List<Artifact>> getTransitiveArtifacts()
         throws MojoExecutionException

--- a/src/main/java/org/codehaus/mojo/nbm/CreateNbmMojo.java
+++ b/src/main/java/org/codehaus/mojo/nbm/CreateNbmMojo.java
@@ -50,7 +50,7 @@ import org.netbeans.nbbuild.MakeNBM.Signature;
 
 /**
  * Create the NetBeans module artifact (nbm file), part of "nbm" lifecycle/packaging.
- * <p/>
+ * 
  *
  * @author <a href="mailto:mkleint@codehaus.org">Milos Kleint</a>
  */

--- a/src/main/java/org/codehaus/mojo/nbm/CreateNetBeansFileStructure.java
+++ b/src/main/java/org/codehaus/mojo/nbm/CreateNetBeansFileStructure.java
@@ -66,7 +66,7 @@ import org.netbeans.nbbuild.JHIndexer;
 
 /**
  * Create the NetBeans module directory structure, a prerequisite for nbm creation and cluster creation.
- * <p/>
+ * 
  *
  * @author <a href="mailto:mkleint@codehaus.org">Milos Kleint</a>
  *

--- a/src/main/java/org/codehaus/mojo/nbm/CreateStandaloneMojo.java
+++ b/src/main/java/org/codehaus/mojo/nbm/CreateStandaloneMojo.java
@@ -60,8 +60,8 @@ public class CreateStandaloneMojo
 
     /**
      * 
-     * @throws org.apache.maven.plugin.MojoExecutionException 
-     * @throws org.apache.maven.plugin.MojoFailureException 
+     * @throws MojoExecutionException if an unexpected problem occurs
+     * @throws MojoFailureException if an expected problem occurs
      */
     public void execute()
         throws MojoExecutionException, MojoFailureException

--- a/src/main/java/org/codehaus/mojo/nbm/CreateWebstartAppMojo.java
+++ b/src/main/java/org/codehaus/mojo/nbm/CreateWebstartAppMojo.java
@@ -185,8 +185,8 @@ public class CreateWebstartAppMojo
 
     /**
      * 
-     * @throws org.apache.maven.plugin.MojoExecutionException 
-     * @throws org.apache.maven.plugin.MojoFailureException 
+     * @throws MojoExecutionException if an unexpected problem occurs
+     * @throws MojoFailureException if an expected problem occurs
      */
     @Override
     public void execute()

--- a/src/main/java/org/codehaus/mojo/nbm/NetBeansManifestUpdateMojo.java
+++ b/src/main/java/org/codehaus/mojo/nbm/NetBeansManifestUpdateMojo.java
@@ -65,7 +65,7 @@ import org.codehaus.plexus.util.IOUtil;
  *
  * In order to have the generated manifest picked up by the maven-jar-plugin,
  * one shall add the following configuration snippet to maven-jar-plugin.
- * <p/>
+ * 
  * <pre>
     &lt;plugin&gt;
         &lt;groupId&gt;org.apache.maven.plugins&lt;/groupId&gt;
@@ -275,8 +275,8 @@ public class NetBeansManifestUpdateMojo
 
     /**
      * execute plugin
-     * @throws org.apache.maven.plugin.MojoExecutionException
-     * @throws org.apache.maven.plugin.MojoFailureException
+     * @throws MojoExecutionException if an unexpected problem occurs
+     * @throws MojoFailureException if an expected problem occurs
      */
     public void execute()
         throws MojoExecutionException, MojoFailureException

--- a/src/main/java/org/codehaus/mojo/nbm/RunNetBeansMojo.java
+++ b/src/main/java/org/codehaus/mojo/nbm/RunNetBeansMojo.java
@@ -81,8 +81,8 @@ public class RunNetBeansMojo
 
     /**
      * 
-     * @throws org.apache.maven.plugin.MojoExecutionException 
-     * @throws org.apache.maven.plugin.MojoFailureException 
+     * @throws MojoExecutionException if an unexpected problem occurs
+     * @throws MojoFailureException if an expected problem occurs
      */
     public void execute()
         throws MojoExecutionException, MojoFailureException

--- a/src/main/java/org/codehaus/mojo/nbm/RunPlatformAppMojo.java
+++ b/src/main/java/org/codehaus/mojo/nbm/RunPlatformAppMojo.java
@@ -84,8 +84,8 @@ public class RunPlatformAppMojo
 
     /**
      *
-     * @throws org.apache.maven.plugin.MojoExecutionException 
-     * @throws org.apache.maven.plugin.MojoFailureException 
+     * @throws MojoExecutionException if an unexpected problem occurs
+     * @throws MojoFailureException if an expected problem occurs
      */
     public void execute()
         throws MojoExecutionException, MojoFailureException

--- a/src/test/java/org/codehaus/mojo/nbm/AbstractNbmMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/nbm/AbstractNbmMojoTest.java
@@ -141,6 +141,7 @@ public class AbstractNbmMojoTest extends TestCase {
 
     /**
      * Module is not a library
+     * @throws java.lang.Exception if AbstractNbmMojo.getLibraryArtifacts fail
      */
     public void testGetLibraryArtifacts1() throws Exception {
         System.out.println("getLibraryArtifacts1");
@@ -155,6 +156,7 @@ public class AbstractNbmMojoTest extends TestCase {
 
     /**
      * direct dependency is a library
+     * @throws java.lang.Exception if AbstractNbmMojo.getLibraryArtifacts fail
      */
     public void testGetLibraryArtifact2() throws Exception {
         System.out.println("getLibraryArtifacts2");
@@ -170,6 +172,7 @@ public class AbstractNbmMojoTest extends TestCase {
     
     /**
      * transitive dependency gets included as well.
+     * @throws java.lang.Exception if AbstractNbmMojo.getLibraryArtifacts fail
      */
     public void testGetLibraryArtifact3() throws Exception {
         System.out.println("getLibraryArtifacts3");
@@ -187,6 +190,7 @@ public class AbstractNbmMojoTest extends TestCase {
 
     /**
      * transitive dependency of a module doesn't get included as library
+     * @throws java.lang.Exception if AbstractNbmMojo.getLibraryArtifacts fail
      */
     public void testGetLibraryArtifact4() throws Exception {
         System.out.println("getLibraryArtifacts4");
@@ -203,7 +207,8 @@ public class AbstractNbmMojoTest extends TestCase {
 
     /**
      * transitive dependency of a library is a duplicate of a transitive dependency of a module
-     * ->doesn't get included.
+     * -&gt;doesn't get included.
+     * @throws java.lang.Exception if AbstractNbmMojo.getLibraryArtifacts fail
      */
     public void testGetLibraryArtifact5() throws Exception {
         System.out.println("getLibraryArtifacts5");


### PR DESCRIPTION
This PR is maintenance in order to be able to clean install site with jdk8 and maven 3.3.3.
It's backward compatible with maven 3.0.5
updated lots of version and dependencies

I had to fix some javadoc to limit error and warning (except modello generated)
