### PR TITLE
maven-dependency-analyzer version upgrade to 1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-dependency-analyzer</artifactId>
-            <version>1.9</version>
+            <version>1.10</version>
         </dependency>
         <!-- maven dependecy analyser version 1.8 will have the correct dependency -->
         <dependency>


### PR DESCRIPTION
maven-dependency-analyzer version 1.9 causing following error, if jar file contains module-info.class : 

`Failed to execute goal org.codehaus.mojo:nbm-maven-plugin:4.1:manifest (default-manifest) on project modeler-lib: Execution default-manifest of goal org.codehaus.mojo:nbm-maven-plugin:4.1:manifest failed.: IllegalArgumentException`

Signed-off-by: Gaurav Gupta <gaurav.gupta.jc@gmail.com>